### PR TITLE
Update package.json to get consolidate from npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "bluebird": "^3.0.0",
-    "consolidate": "niftylettuce/consolidate.js",
+    "consolidate": "^0.14.1",
     "debug": "^2.2.0",
     "glob": "^6.0.0",
     "juice": "^2.0.0",


### PR DESCRIPTION
This removes the requirement for Git to be installed. This can be an issue with automated deployments like in AWS Elastic Beanstalk.